### PR TITLE
Added prop rippleDisabled

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   StyleProp,
   GestureResponderEvent,
+  TouchableWithoutFeedback,
 } from 'react-native';
 import color from 'color';
 
@@ -24,6 +25,11 @@ type Props = $RemoveChildren<typeof TouchableRipple> & {
    * Color of the icon.
    */
   color?: string;
+  
+  /**
+   * Disable ripple.
+   */
+  rippleDisabled?: boolean;
   /**
    * Size of the icon.
    */
@@ -93,6 +99,7 @@ const IconButton = ({
   animated = false,
   theme,
   style,
+  disabledRipple = false,
   ...rest
 }: Props) => {
   const iconColor =
@@ -103,8 +110,11 @@ const IconButton = ({
     .string();
   const IconComponent = animated ? CrossFadeIcon : Icon;
   const buttonSize = size * 1.5;
+  
+  const TouchableComponent = rippleDisabled ? TouchableWithoutFeedback : TouchableRipple
+  
   return (
-    <TouchableRipple
+    <TouchableComponent
       borderless
       centered
       onPress={onPress}
@@ -132,7 +142,7 @@ const IconButton = ({
       <View>
         <IconComponent color={iconColor} source={icon} size={size} />
       </View>
-    </TouchableRipple>
+    </TouchableComponent>
   );
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

I want to make a touchable icon without the ripple effect ( without feedback ) because I already added another way to give feedback

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan


1. Use `IconButton` with any normal prop and see ripple effect
2. Now pass boolean prop `rippleDisabled`  to remove ripple effect

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
